### PR TITLE
Added checking for attributes not mentioned in contract

### DIFF
--- a/lib/service_contract/assertions.rb
+++ b/lib/service_contract/assertions.rb
@@ -16,6 +16,10 @@ module ServiceContract
         # type should have fields
         type.fields.each do |field|
 
+          #Does data contain attributes that the contract doesn't specify?
+          data_extra_attrs = (data.keys.map(&:to_sym) - type.fields.map{|n| n.name.to_sym})
+          assert_equal 0, data_extra_attrs.size, "#{type.name} contains attributes not described in contract: #{data_extra_attrs.join(',')}"
+
           # ensure the field is present
           value = data.fetch(field.name) do
             data.fetch(field.name.to_sym) do

--- a/test/assertions_test.rb
+++ b/test/assertions_test.rb
@@ -58,4 +58,24 @@ class AssertionsTest < Minitest::Test
     assert_endpoint_response([{customer_id: [1,2,3]}], endpoint)
   end
 
+  def test_uncontracted_data_not_matching
+    service = SampleService.find(2)
+    assert service, "expect to find a service by version"
+
+    protocol = service.protocol("search_param")
+    endpoint = protocol.endpoint("index")
+
+    # test can be nil
+    failure_data = nil
+    begin
+      assert_endpoint_response([{customer_id: nil, bogus_param: 1}], endpoint)
+    rescue Minitest::Assertion => failure
+      failure_data = failure
+    end
+
+    assert !failure_data.nil?
+    assert failure_data.to_s.include?("not described in contract: bogus_param")
+
+  end
+
 end


### PR DESCRIPTION
Currently, the assertions to assert response data's abidance to the contract do not cover the data having attributes that the contract doesn't. In the spirit of a service strictly abiding to it's contract, it seems reasonable to assert against cases like this.