### PR TITLE
parse out formatting at the front of the doc string to override endpoint...

### DIFF
--- a/lib/service_contract/avro/endpoint.rb
+++ b/lib/service_contract/avro/endpoint.rb
@@ -25,6 +25,11 @@ module ServiceContract
       protected
 
       def request_method
+        #Check for [<METHOD>] at the front of the doc string. this signals an action override
+        if doc =~ /^\[([A-Z]+)\].+$/
+          return $1
+        end
+
         case name
         when "create"
           "POST"


### PR DESCRIPTION
Currently, when creating a custom endpoint, the HTTP method defaults to GET. By adding a clause to detect a method override in the doc string, we can define the method ourselves.

This is done by putting the method in square brackets at the start of the doc string eg.   
```
/** [POST] Create stuff in a cool, different way */
```   
