### PR TITLE
allow nil structs in assertion and version bump

### DIFF
--- a/lib/service_contract/assertions.rb
+++ b/lib/service_contract/assertions.rb
@@ -12,7 +12,8 @@ module ServiceContract
           assert_data_matches_type(datum, type.subtype, allow_nil)
         end
       elsif type.complex?
-
+        # Skip out of the complex object is nil and allowed to be nil
+        return true if data.nil? && allow_nil
         # type should have fields
         type.fields.each do |field|
 

--- a/lib/service_contract/version.rb
+++ b/lib/service_contract/version.rb
@@ -1,3 +1,3 @@
 module ServiceContract
-  VERSION = "0.2.0"
+  VERSION = "0.2.0""
 end

--- a/lib/service_contract/version.rb
+++ b/lib/service_contract/version.rb
@@ -1,3 +1,3 @@
 module ServiceContract
-  VERSION = "0.2.0""
+  VERSION = "0.2.1"
 end

--- a/lib/service_contract/version.rb
+++ b/lib/service_contract/version.rb
@@ -1,3 +1,3 @@
 module ServiceContract
-  VERSION = "0.2.1"
+  VERSION = "0.2.0"
 end


### PR DESCRIPTION
Assertions fail if there is an expected complex object, but the value was nil since there was an expectation of fields.