### PR TITLE
Change from random-word gem to faker for random words

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,5 +5,5 @@ gemspec
 
 group :test do
   gem 'codeclimate-test-reporter', require: nil
-  gem 'random-word'
+  gem 'faker'
 end

--- a/lib/service_contract/mock.rb
+++ b/lib/service_contract/mock.rb
@@ -1,4 +1,4 @@
-require 'random-word'
+require 'faker'
 
 module ServiceContract
   class Mock
@@ -45,7 +45,7 @@ module ServiceContract
           when "int", :int
             Random.new.rand(10000000)
           when "string", :string
-            RandomWord.nouns.next
+            Faker::Hacker.noun
           when "float", :float
             Random.new.rand(10000.0)
           when "boolean", :boolean

--- a/lib/service_contract/version.rb
+++ b/lib/service_contract/version.rb
@@ -1,3 +1,3 @@
 module ServiceContract
-  VERSION = "0.2.0.randword"
+  VERSION = "0.2.0"
 end

--- a/lib/service_contract/version.rb
+++ b/lib/service_contract/version.rb
@@ -1,3 +1,3 @@
 module ServiceContract
-  VERSION = "0.2.0"
+  VERSION = "0.2.0.randword"
 end

--- a/service_contract.gemspec
+++ b/service_contract.gemspec
@@ -22,5 +22,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest", "~> 5"
-  spec.add_development_dependency "random-word"
+  spec.add_development_dependency "faker"
 end


### PR DESCRIPTION
random-word is not thread safe. 

There are a few git issues about it but using it with the mock generation can result in thread issues and Fiber exceptions.  This particular case is with run time auto-generation of random contract mock data.

```ruby
FiberException: fiber called across threads
```
So instead of trying to rewrite random-word, I'm suggesting we use Faker.