### PR TITLE
Json api

### DIFF
--- a/lib/service_contract/avro/documentation.rb
+++ b/lib/service_contract/avro/documentation.rb
@@ -44,6 +44,7 @@ module ServiceContract
             name: service.name,
             title: service.title,
             description: service.description,
+            release_version: release_version,
             versions: service.all.map { |version|
               {
                 version: version.version,
@@ -63,6 +64,10 @@ module ServiceContract
 
         def request_json?
           request.accept.map(&:entry).include?("application/json")
+        end
+
+        def release_version
+          service.const_defined?("VERSION") ? service.const_get("VERSION") : ""
         end
       end
     end

--- a/lib/service_contract/avro/documentation.rb
+++ b/lib/service_contract/avro/documentation.rb
@@ -8,7 +8,12 @@ module ServiceContract
       get '/:version/:protocol' do
         version = service.find(params[:version])
         protocol = version.protocol(params[:protocol])
-        slim :protocol, locals: { version: version, protocol: protocol }
+        if request_json?
+          content_type "application/json"
+          send_file File.join(service.data_dir, version.version, "compiled", "#{protocol.name}.avpr")
+        else
+          slim :protocol, locals: { version: version, protocol: protocol }
+        end
       end
 
       get '/:version' do

--- a/lib/service_contract/avro/documentation.rb
+++ b/lib/service_contract/avro/documentation.rb
@@ -15,7 +15,19 @@ module ServiceContract
         version = service.find(params[:version])
 
         if version
-          slim :version, locals: { version: version }
+          if request_json?
+            json version: {
+              version: version.version,
+              protocols: version.protocols.map { |protocol|
+                {
+                  name: protocol.name,
+                  link: "/#{version.version}/#{protocol.name}"
+                }
+              }
+            }
+          else
+            slim :version, locals: { version: version }
+          end
         else
           status 404
         end

--- a/lib/service_contract/avro/documentation.rb
+++ b/lib/service_contract/avro/documentation.rb
@@ -1,4 +1,5 @@
 require 'sinatra/base'
+require 'sinatra/json'
 require 'slim'
 
 module ServiceContract
@@ -21,12 +22,30 @@ module ServiceContract
       end
 
       get '/' do
-        slim :homepage
+        if request_json?
+          json contract: {
+            name: service.name,
+            title: service.title,
+            description: service.description,
+            versions: service.all.map { |version|
+              {
+                version: version.version,
+                link: "/#{version.version}"
+              }
+            }
+          }
+        else
+          slim :homepage
+        end
       end
 
       helpers do
         def service
           raise :not_implemented
+        end
+
+        def request_json?
+          request.accept.map(&:entry).include?("application/json")
         end
       end
     end

--- a/service_contract.gemspec
+++ b/service_contract.gemspec
@@ -23,4 +23,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest", "~> 5"
   spec.add_development_dependency "faker"
+  spec.add_development_dependency "sinatra"
+  spec.add_development_dependency "slim"
+  spec.add_development_dependency "rack-test"
+  spec.add_development_dependency "capybara"
 end

--- a/service_contract.gemspec
+++ b/service_contract.gemspec
@@ -27,4 +27,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "slim"
   spec.add_development_dependency "rack-test"
   spec.add_development_dependency "capybara"
+  spec.add_development_dependency "sinatra-contrib"
+  spec.add_development_dependency "pry"
 end

--- a/test/documentation_json_test.rb
+++ b/test/documentation_json_test.rb
@@ -42,4 +42,11 @@ class DocumentationJsonTest < Minitest::Test
       ]
     }}, JSON.parse(last_response.body))
   end
+
+  def test_protocol_json
+    get '/1/city_state'
+    assert_equal "application/json", last_response.headers["Content-Type"]
+    assert_equal File.read(File.expand_path("../sample/1/compiled/city_state.avpr", __FILE__)),
+      last_response.body
+  end
 end

--- a/test/documentation_json_test.rb
+++ b/test/documentation_json_test.rb
@@ -11,8 +11,12 @@ class DocumentationJsonTest < Minitest::Test
     SampleDocumentation
   end
 
-  def test_homepage_json
+  def setup
+    super
     header "Accept", "application/json"
+  end
+
+  def test_homepage_json
     get '/'
     assert_equal "application/json", last_response.headers["Content-Type"]
     assert_equal({"contract" => {
@@ -22,6 +26,19 @@ class DocumentationJsonTest < Minitest::Test
       "versions" => [
         {"version" => "1", "link" => "/1"},
         {"version" => "2", "link" => "/2"},
+      ]
+    }}, JSON.parse(last_response.body))
+  end
+
+  def test_version_index_json
+    get '/1'
+    assert_equal "application/json", last_response.headers["Content-Type"]
+    assert_equal({"version" => {
+      "version" => "1",
+      "protocols" => [
+        {"name" => "city_state", "link" => "/1/city_state"},
+        {"name" => "location", "link" => "/1/location"},
+        {"name" => "sales_region", "link" => "/1/sales_region"},
       ]
     }}, JSON.parse(last_response.body))
   end

--- a/test/documentation_json_test.rb
+++ b/test/documentation_json_test.rb
@@ -1,0 +1,28 @@
+ENV['RACK_ENV'] = 'test'
+
+require 'test_helper'
+require 'rack/test'
+require 'service_contract/avro/documentation'
+
+class DocumentationJsonTest < Minitest::Test
+  include Rack::Test::Methods
+
+  def app
+    SampleDocumentation
+  end
+
+  def test_homepage_json
+    header "Accept", "application/json"
+    get '/'
+    assert_equal "application/json", last_response.headers["Content-Type"]
+    assert_equal({"contract" => {
+      "name" => "SampleService",
+      "title" => "Avro Service",
+      "description" => "",
+      "versions" => [
+        {"version" => "1", "link" => "/1"},
+        {"version" => "2", "link" => "/2"},
+      ]
+    }}, JSON.parse(last_response.body))
+  end
+end

--- a/test/documentation_json_test.rb
+++ b/test/documentation_json_test.rb
@@ -23,6 +23,7 @@ class DocumentationJsonTest < Minitest::Test
       "name" => "SampleService",
       "title" => "Avro Service",
       "description" => "",
+      "release_version" => "0.1.2",
       "versions" => [
         {"version" => "1", "link" => "/1"},
         {"version" => "2", "link" => "/2"},

--- a/test/documentation_test.rb
+++ b/test/documentation_test.rb
@@ -1,0 +1,40 @@
+ENV['RACK_ENV'] = 'test'
+
+require 'test_helper'
+require 'rack/test'
+require 'capybara'
+require 'capybara/dsl'
+require 'service_contract/avro/documentation'
+
+class DocumentationTest < Minitest::Test
+  include Capybara::DSL
+
+  class SampleDocumentation < ServiceContract::Avro::Documentation
+    def service
+      SampleService
+    end
+  end
+
+  def setup
+    super
+    Capybara.app = SampleDocumentation
+  end
+
+  def test_homepage_html
+    visit '/'
+    assert page.find("a[href='http://www.example.com/1']", text: "Version 1")
+    assert page.find("a[href='http://www.example.com/2']", text: "Version 2")
+  end
+
+  def test_version_index_html
+    visit '/1'
+    assert page.find("a[href='http://www.example.com/1/city_state']", text: "city_state")
+    assert page.find("a[href='http://www.example.com/1/location']", text: "location")
+    assert page.find("a[href='http://www.example.com/1/sales_region']", text: "sales_region")
+  end
+
+  def test_version_protocol_html
+    visit '/1/city_state'
+    assert page.has_content?("CityState params")
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,3 +8,9 @@ class SampleService < ServiceContract::Avro::Service
     File.expand_path("../sample", __FILE__)
   end
 end
+
+class SampleDocumentation < ServiceContract::Avro::Documentation
+  def service
+    SampleService
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,6 +4,8 @@ require 'minitest/autorun'
 require 'service_contract'
 
 class SampleService < ServiceContract::Avro::Service
+  VERSION = "0.1.2"
+
   def self.data_dir
     File.expand_path("../sample", __FILE__)
   end


### PR DESCRIPTION
Adds JSON formatted responses for the documentation service.

```
# GET / Accept: application/json
{
  "contract": {
    "name": "SampleService",
    "title": "Avro Service",
    "description": "",
    "versions": [
      {
        "version": "1",
        "link": "/1"
      },
      {
        "version": "2",
        "link": "/2"
      }
    ]
  }
}
```

```
# GET /1 Accept: application/json
{
  "version": {
    "version": "1",
    "protocols": [
      {
        "name": "city_state",
        "link": "/1/city_state"
      },
      {
        "name": "location",
        "link": "/1/location"
      },
      {
        "name": "sales_region",
        "link": "/1/sales_region"
      }
    ]
  }
}
```

```
# GET /1/city_state Accept: application/json
# => returns the city_state.avpr
```
